### PR TITLE
handle a case where whatsapp user doesn't have last name

### DIFF
--- a/index.channel.ts
+++ b/index.channel.ts
@@ -632,7 +632,7 @@ export default class WhatsAppHandler extends ChannelHandler<
     const [firstName, ...rest] = userName
       ? userName.split(' ')
       : ['Anonymous', 'Subscriber'];
-    const lastName = rest.join(' ');
+    const lastName = rest.length > 0 ? rest.join(' ') : firstName;
 
     // @TODO: Check if there is a way to retrieve the avatar
 


### PR DESCRIPTION
# Fix WhatsApp subscriber last name handling

## Problem
When a WhatsApp subscriber has only provided a single name (no last name), there was a mongoose exception says the last_name is a required attribute of a Subscriber model.

## Solution
- When multiple names are provided, join all names after the first as the last name
- When only a single name is provided, leave the last name as the first name (maintaining existing behavior)

This is a bug fix that improves data accuracy for WhatsApp subscribers.